### PR TITLE
Fix broken URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ AP is a good choice if the business needs allow for [eventual consistency](#even
 ### Source(s) and further reading
 
 * [CAP theorem revisited](http://robertgreiner.com/2014/08/cap-theorem-revisited/)
-* [A plain english introduction to CAP theorem](http://ksat.me/a-plain-english-introduction-to-cap-theorem/)
+* [A plain english introduction to CAP theorem](http://ksat.me/a-plain-english-introduction-to-cap-theorem)
 * [CAP FAQ](https://github.com/henryr/cap-faq)
 
 ## Consistency patterns


### PR DESCRIPTION
Linked GitHub pages site not configured to handle trailing slash. Removing the trailing slash from our link directs user to correct blog post.